### PR TITLE
Remove formatting in thread, to put it in format function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: "27.1.2"
-          gleam-version: "1.6.2"
-          rebar3-version: "3"
+          otp-version: '27.1.2'
+          gleam-version: '1.8.1'
+          rebar3-version: '3.24.0'
           # elixir-version: "1.15.4"
       - run: gleam deps download
       - run: gleam test

--- a/src/palabres/internals/utils.gleam
+++ b/src/palabres/internals/utils.gleam
@@ -1,17 +1,6 @@
 //// Collection of utils to work with internal structures.
 //// Should never be leaked outside of the package.
 
-/// Indicates if the current palabres instance has JSON mode activated or not.
-@external(erlang, "palabres_ffi", "is_json")
-@external(javascript, "../../palabres.ffi.mjs", "isJson")
-pub fn is_json() -> Bool
-
-/// Indicates if the current palabres instance has color activated or not.
-/// Color is deactivated if JSON is activated.
-@external(erlang, "palabres_ffi", "is_color")
-@external(javascript, "../../palabres.ffi.mjs", "isColor")
-pub fn is_color() -> Bool
-
 /// Generates the current date (i.e. now) in ISO-8601 format, in string.
 /// The date is in UTC.
 @external(erlang, "palabres_ffi", "format_iso8601")

--- a/test/palabres/level_test.gleam
+++ b/test/palabres/level_test.gleam
@@ -4,9 +4,13 @@ import startest.{describe, it}
 import startest/expect
 
 const levels = [
-  #("emergency", level.Emergency), #("alert", level.Alert),
-  #("critical", level.Critical), #("error", level.Error),
-  #("warning", level.Warning), #("notice", level.Notice), #("info", level.Info),
+  #("emergency", level.Emergency),
+  #("alert", level.Alert),
+  #("critical", level.Critical),
+  #("error", level.Error),
+  #("warning", level.Warning),
+  #("notice", level.Notice),
+  #("info", level.Info),
   #("debug", level.Debug),
 ]
 


### PR DESCRIPTION
In Erlang loggers, formatting should happen within formatter, with no information leaking outside.
That pull request fixes that behaviour, by putting the hard formatting work in the formatter duty, and no more in the `palabres` side.

### Issues
- Closes #2 